### PR TITLE
[AE-432] Add Nicla Vision to build script

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -62,6 +62,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      - name: Checkout private library repo
+        uses: actions/checkout@v4
+        with:
+          repository: bcmi-labs/Arduino_LowPowerNiclaVision
+          token: ${{ secrets.GH_PAT }}
+          path: Arduino_LowPowerNiclaVision
 
       - name: Compile examples
         uses: arduino/compile-sketches@v1
@@ -74,7 +81,8 @@ jobs:
             - name: Arduino_PF1550
             - name: Arduino_LowPowerPortentaH7
             - source-url: https://github.com/arduino-libraries/Arduino_LowPowerPortentaC33.git
-            - source-url: https://github.com/bcmi-labs/Arduino_LowPowerNiclaVision.git
+            - source-path: ./Arduino_LowPowerNiclaVision
+          
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.board.additional-sketch-paths }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -54,6 +54,10 @@ jobs:
             artifact-name-suffix: arduino-renesas_portenta-portenta_c33
             additional-sketch-paths: |
               - examples/Standby_WakeFromRTC_C33
+          - fqbn: arduino:mbed_nicla:nicla_vision
+            platforms: |
+              - name: arduino:mbed_nicla
+            artifact-name-suffix: arduino-mbed_nicla-nicla_vision
 
     steps:
       - name: Checkout repository
@@ -70,6 +74,7 @@ jobs:
             - name: Arduino_PF1550
             - name: Arduino_LowPowerPortentaH7
             - source-url: https://github.com/arduino-libraries/Arduino_LowPowerPortentaC33.git
+            - source-url: https://github.com/bcmi-labs/Arduino_LowPowerNiclaVision.git
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.board.additional-sketch-paths }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,7 +25,6 @@ env:
   UNIVERSAL_SKETCH_PATHS: |
     - examples/Battery
     - examples/Charger
-    - examples/Standby_WakeFromPin
   SKETCHES_REPORTS_PATH: sketches-reports
   SKETCHES_REPORTS_ARTIFACT_NAME: sketches-reports
 
@@ -48,12 +47,14 @@ jobs:
             artifact-name-suffix: arduino-mbed_portenta-envie_m7
             additional-sketch-paths: |
               - examples/Standby_WakeFromRTC_H7
+              - examples/Standby_WakeFromPin
           - fqbn: arduino:renesas_portenta:portenta_c33
             platforms: |
               - name: arduino:renesas_portenta
             artifact-name-suffix: arduino-renesas_portenta-portenta_c33
             additional-sketch-paths: |
               - examples/Standby_WakeFromRTC_C33
+              - examples/Standby_WakeFromPin
           - fqbn: arduino:mbed_nicla:nicla_vision
             platforms: |
               - name: arduino:mbed_nicla

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -63,13 +63,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Checkout private library repo
-        uses: actions/checkout@v4
-        with:
-          repository: bcmi-labs/Arduino_LowPowerNiclaVision
-          token: ${{ secrets.GH_PAT }}
-          path: Arduino_LowPowerNiclaVision
-
       - name: Compile examples
         uses: arduino/compile-sketches@v1
         with:
@@ -81,8 +74,6 @@ jobs:
             - name: Arduino_PF1550
             - name: Arduino_LowPowerPortentaH7
             - source-url: https://github.com/arduino-libraries/Arduino_LowPowerPortentaC33.git
-            - source-path: ./Arduino_LowPowerNiclaVision
-          
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.board.additional-sketch-paths }}


### PR DESCRIPTION
This PR adds the Nicla Vision to the example build script:
- 🔍 The following three examples, common to all boards, are covered by the build script for Nicla Vision
    - examples/Battery
    - examples/Charger
    - ~examples/Standby_WakeFromPin~
- 📚 Currently, the Arduino_LowPowerNiclaVision library is not `include`d in any of the examples nor source file. It is expected that this would change, given the compiler directives for the Nicla Vision e.g. https://github.com/arduino-libraries/Arduino_PowerManagement/blob/70b26666891fb0744a7dff2b922f871eb96d3f30/src/Board.cpp#L107-L119
- 🔑 A PAT is used to access the Low Power library for the Nicla Vision (see [here](https://github.com/arduino/compile-sketches/issues/312#issuecomment-2302691927)). 