### PR TITLE
AE-591: "turnOffEthernet" relocation to be executed before turning rails off.

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,9 +1,11 @@
 #include "Board.h"
 #include "MAX1726Driver.h"
-#include "Arduino_LowPowerPortentaH7.h"
 #include <map>
 
-LowPowerPortentaH7& PortentaH7 = LowPowerPortentaH7::getInstance();
+#if defined(ARDUINO_PORTENTA_H7)
+#include "Arduino_LowPowerPortentaH7.h"
+LowPowerPortentaH7& lowPowerPortentaH7 = LowPowerPortentaH7::getInstance();
+#endif
 
 constexpr int UNKNOWN_VALUE = 0xFF;
 
@@ -197,13 +199,14 @@ void Board::setAllPeripheralsPower(bool on){
         PMIC.getControl() -> turnLDO3On(Ldo3Mode::Normal);
         PMIC.getControl() -> turnSw1On(Sw1Mode::Normal);
     } else {
+        #if defined(ARDUINO_PORTENTA_H7)
         // Ethernet must be turned off before we enter Standby Mode, because
         // otherwise, the Ethernet transmit termination resistors will overheat
         // from the voltage that gets applied over them. It would be 125 mW in each
         // of them, while they are rated at 50 mW. If we fail to turn off Ethernet,
         // we must not proceed.
 
-        if (false == PortentaH7.turnOffEthernet())
+        if (false == lowPowerPortentaH7.turnOffEthernet())
         {
             {
                 while(1)
@@ -215,6 +218,7 @@ void Board::setAllPeripheralsPower(bool on){
                 }
             }
         }
+        #endif
         PMIC.getControl() -> turnLDO1Off(Ldo1Mode::Normal);
         PMIC.getControl() -> turnLDO2Off(Ldo2Mode::Normal);
         PMIC.getControl() -> turnLDO3Off(Ldo3Mode::Normal);

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,6 +1,9 @@
 #include "Board.h"
 #include "MAX1726Driver.h"
+#include "Arduino_LowPowerPortentaH7.h"
 #include <map>
+
+LowPowerPortentaH7& PortentaH7 = LowPowerPortentaH7::getInstance();
 
 constexpr int UNKNOWN_VALUE = 0xFF;
 
@@ -194,8 +197,26 @@ void Board::setAllPeripheralsPower(bool on){
         PMIC.getControl() -> turnLDO3On(Ldo3Mode::Normal);
         PMIC.getControl() -> turnSw1On(Sw1Mode::Normal);
     } else {
-        PMIC.getControl() -> turnLDO2Off(Ldo2Mode::Normal);
+        // Ethernet must be turned off before we enter Standby Mode, because
+        // otherwise, the Ethernet transmit termination resistors will overheat
+        // from the voltage that gets applied over them. It would be 125 mW in each
+        // of them, while they are rated at 50 mW. If we fail to turn off Ethernet,
+        // we must not proceed.
+
+        if (false == PortentaH7.turnOffEthernet())
+        {
+            {
+                while(1)
+                {
+                    digitalWrite(LEDR, LOW);
+                    delay(500);
+                    digitalWrite(LEDR, HIGH);
+                    delay(500);
+                }
+            }
+        }
         PMIC.getControl() -> turnLDO1Off(Ldo1Mode::Normal);
+        PMIC.getControl() -> turnLDO2Off(Ldo2Mode::Normal);
         PMIC.getControl() -> turnLDO3Off(Ldo3Mode::Normal);
         PMIC.getControl() -> turnSw1Off(Sw1Mode::Normal);
     }


### PR DESCRIPTION
Moved call to "turnOffEthernet" in "setAllPeripheralsPower" to be executed just before we set the peripheral rails to off. This way we make sure the Eth Phy is still powered when sending the command to turn it off, and afterwards we can also turn all rails off as well.